### PR TITLE
TYPO: stats.norm should be used instead of stats.normal to declare the normal distribution

### DIFF
--- a/notebooks/solutions/uniform.py
+++ b/notebooks/solutions/uniform.py
@@ -1,6 +1,6 @@
 #1
 
-distribution = stats.normal(0, 1)
+distribution = stats.norm(0, 1)
 
 x_values = np.linspace(-3, 3, 1000)
 y = distribution.pdf(x_values)


### PR DESCRIPTION
I'm unsure why a normal distribution is plotted in this solution as the exercise is about the uniform distribution.