### PR TITLE
Fixed the calculation of sample standard deviation

### DIFF
--- a/notebooks/solutions/confidence_intervals.py
+++ b/notebooks/solutions/confidence_intervals.py
@@ -30,7 +30,7 @@ for i in iters:
 
 mu = np.mean(means)
 std = np.std(means)
-stats.norm.interval(0.95, loc=mu, scale=std/sqrt(1000))
+stats.norm.interval(0.95, loc=mu, scale=std)
 
 # 4 
 pool = data["InterestRate"].dropna()


### PR DESCRIPTION
This is a fix for the solution of an exercise in module 2.3.2.

I think the standard deviation of the sample mean (std in the solution) should be approximately equal to the full population standard deviation divided by the square root of the **sample size**, i.e. np.std(means) = np.std(pool)/np.sqrt(samp_size). We are then fine to just use np.std(means).

The previous solution took the standard deviation of the sample mean and divided by the **number of samples**. 

https://stats.libretexts.org/Bookshelves/Introductory_Statistics/Book%3A_Introductory_Statistics_(Shafer_and_Zhang)/06%3A_Sampling_Distributions/6.01%3A_The_Mean_and_Standard_Deviation_of_the_Sample_Mean#:~:text=The%20standard%20deviation%20of%20the%20sample%20mean%20%CB%89X%20that,%3D%E2%88%9A20%2F%E2%88%9A2.