### PR TITLE
Update solution for simulation_ttest

### DIFF
--- a/notebooks/solutions/simulation_ttest.py
+++ b/notebooks/solutions/simulation_ttest.py
@@ -1,12 +1,14 @@
-
+from math import floor, ceil
 import numpy as np
+import pandas as pd
 
 def run_experiment(dof):
     """Runs a single t-value experiment"""
     
-    # Create random sizes for each dataset
-    n1 = np.random.randint(3, dof + 2 - 1)
-    n2 = (dof + 2) - n1
+    n1 = floor(dof/2) + 1
+    n2 = ceil(dof/2) + 1
+
+    assert(dof == n1 + n2 - 2)
     
     X1 = np.random.randn(n1)
     X2 = np.random.randn(n2)
@@ -16,39 +18,34 @@ def run_experiment(dof):
     
     sed = np.sqrt(e1**2 + e2**2)
     
-    t_stat = (np.mean(X1) - np.mean(X2)) / sed
+    t_stat = abs((np.mean(X1) - np.mean(X2)) / sed)
     return t_stat
 
 N_EXPERIMENTS = 10000
+dofs = [5, 10, 20, 50, 100]
+p_values = [0.01, 0.02, 0.05, 0.1, 0.2, 0.5]
 
 results = {}
 
-for dof in [5, 10, 20, 50, 100, 500]:
-    print("dof", dof)
+for dof in dofs:
     results[dof] = {}
     values = [run_experiment(dof) for _ in range(N_EXPERIMENTS)]
-    values.sort()  # In place operation
-    for p_value in [0.01, 0.02, 0.05, 0.1, 0.2, 0.5]:
+    values.sort(reverse=True)  # In place operation
+    for p_value in p_values:
         n = int(N_EXPERIMENTS * p_value)
-        results[dof][p_value] = values[n]
-    print(results[dof])
+        results[dof][p_value] = values[n-1]
+    
+results = pd.DataFrame.from_dict(results)
+print(results)
 
-dof = 500
+# Check our results:
+from scipy.special import stdtrit
 
-# Compare to the version implemented in scipy
-# NOte that Absolute values of the t test should be used
-n1 = 249
-n2 = 249
-X1 = np.random.randn(n1)
-X2 = np.random.randn(n2)
+true_results = {}
+for dof in dofs:
+    true_results[dof] = {}
+    for p_value in p_values:
+        true_results[dof][p_value] = stdtrit(dof, 1 - p_value / 2)
 
-stat, p = stats.ttest_ind(X1, X2)
-stat, p
-
-results[dof]
-
-import pandas as pd
-
-tstats = pd.DataFrame(results)
-
-tstats
+true_results = pd.DataFrame.from_dict(true_results)
+print(true_results)


### PR DESCRIPTION
Unless I've missed something, there are a few problems with the existing solution to the final Extended Exercise in Module 2.1.1 - Hypothesis Testing. They include:
- By default sort() runs from highest to lowest, which needs to be flipped in the current approach to finding pvalues
- We require the absolute value of the difference in the means to calculate the t_stat
- The number of samples in the random variables do not match the requirements for the stated degrees of freedom
- It's nice to include the 'correct' values from scipy for comparison

This MR changes the solution to resolve the above issues.

Example output from running this solution:
```
           5         10        20        50        100
0.01  4.918404  3.389937  2.956859  2.791317  2.584174
0.02  4.069923  2.996797  2.659391  2.462646  2.368306
0.05  3.170879  2.407383  2.183557  2.061922  1.997612
0.10  2.432624  1.950381  1.805861  1.729657  1.660668
0.20  1.767502  1.498065  1.379952  1.334671  1.290840
0.50  0.859306  0.765841  0.716850  0.698637  0.678042
           5         10        20        50        100
0.01  4.032143  3.169273  2.845340  2.677793  2.625891
0.02  3.364930  2.763769  2.527977  2.403272  2.364217
0.05  2.570582  2.228139  2.085963  2.008559  1.983972
0.10  2.015048  1.812461  1.724718  1.675905  1.660234
0.20  1.475884  1.372184  1.325341  1.298714  1.290075
0.50  0.726687  0.699812  0.686954  0.679428  0.676951
```