### PR TITLE
Update for deprecated sklearn and altair data transformer setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 **/__pycache__/
 **/*.egg-info/
 altair*.json
+**/altair-temp-data/
 
 my_secrets.py
 

--- a/notebooks/Module 1.1.1 - Overview.ipynb
+++ b/notebooks/Module 1.1.1 - Overview.ipynb
@@ -51,7 +51,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.11.0 (main, Oct 24 2022, 18:26:48) [MSC v.1933 64 bit (AMD64)]\n"
+      "3.11.8 | packaged by Anaconda, Inc. | (main, Feb 26 2024, 21:34:05) [MSC v.1916 64 bit (AMD64)]\n"
      ]
     }
    ],
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -175,7 +175,9 @@
     "\n",
     "If you've installed Python yourself, you probably know how to install modules for your system. If you are unsure, try: `pip install my_module`\n",
     "\n",
-    "You may also find the command `pip install -r requirements.txt` useful."
+    "You may also find the command `pip install -r requirements.txt` useful. \n",
+    "\n",
+    "The `maxentropy` package in `requirements.txt` requires deprecated `sklearn` (updated to `scikit-learn`), so first run `set SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True` before `pip install -r requirements.txt`. Deprecated `sklearn` can then be uninstalled with `pip uninstall sklearn`."
    ]
   }
  ],
@@ -195,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/setup.ipy
+++ b/notebooks/setup.ipy
@@ -1,9 +1,18 @@
 
 import pandas as pd
 import altair as alt
+
 if not alt.data_transformers.active == 'json':  # Check json isn't already active
-    alt.data_transformers.enable('json')
+    import os
+    # Make a temp folder to put these json files in - Altair creates a lot of them!
+    dataset_temp_name = 'altair-temp-data/'
+    if not os.path.exists(dataset_temp_name):
+        # if the folder doesn't exist, create it
+        os.mkdir(dataset_temp_name)
+    # Tell Altair to temporary save datasets it needs to that folder
+    alt.data_transformers.enable('json', prefix=dataset_temp_name)
 alt.renderers.enable('default')
+
 from scipy import stats
 
 import random

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ jupyter
 notebook
 pytest
 statsmodels
-sklearn
+scikit-learn
 tensorflow
 tables
 quandl


### PR DESCRIPTION
Changed requirements.txt to reflect deprecation of sklearn and added instructions (in Overview notebook) for avoiding errors when installing maxentropy package (due to requiring deprecated sklearn).
setup.ipy now includes specification of a temp folder for altair json files so that all notebooks avoid cluttering the directory.