### PR TITLE
fixed typo for conda activation code

### DIFF
--- a/notebooks/Module 1.1.1 - Overview.ipynb
+++ b/notebooks/Module 1.1.1 - Overview.ipynb
@@ -171,7 +171,7 @@
     "\n",
     "which creates a `quant_finance` environment. You can activate this environment using:\n",
     "\n",
-    "    conda env activate quant_finance\n",
+    "    conda activate quant_finance\n",
     "\n",
     "and then re-run the Jupyter notebook/lab in this environment to use all the required packages.\n",
     "\n",


### PR DESCRIPTION
The code in the first notebook contains a typo when guiding the new user to activate an environment. I have fixed it here.