### PR TITLE
Correct explanation for transpose.

### DIFF
--- a/notebooks/Module 1.3.2 - Multivariate OLS.ipynb
+++ b/notebooks/Module 1.3.2 - Multivariate OLS.ipynb
@@ -683,7 +683,7 @@
     "* **diagonal matrix**: A square matrix, where only values on the diagonal are non-zero and all other values are zero. That is, for value in position (i, j), it is zero if $i\\neq j$, and *may be non-zero* only if $i=j$\n",
     "* **identity matrix**: A diagonal matrix where *all* diagonal elements are 1. It is denoted as $I$, and usually the size is implied by the context (i.e. if you are computing the dot product $XI$, then $I$ will be a square matrix with the size of the second dimension of $X$).\n",
     "* **scalar matrix**: A diagonal matrix where *all* diagonal elements are some scalar value. Its size too can often be implied by the context.\n",
-    "* **transpose**: rotating a matrix 90°, denoted by a quote symbol. That is, the transpose of $A$ is $A'$, and it has values such that $A_{i, j} = A'_{j, i}$. The transpose of the transpose of a matrix is equal to the original matrix, i.e. $A'' = A$.\n",
+    "* **transpose**: reflect a matrix on the diagonal, denoted by a quote symbol. That is, the transpose of $A$ is $A'$, and it has values such that $A_{i, j} = A'_{j, i}$. The transpose of the transpose of a matrix is equal to the original matrix, i.e. $A'' = A$.\n",
     "* **symmetric matrix**: A matrix that is equal to its transpose.\n",
     "* **null matrix/vector**: A matrix/vector where all values are 0. Its size is often implied from the context.\n"
    ]


### PR DESCRIPTION
Correct explanation for transpose from 'rotate matrix by 90º' to 'reflect matrix on the diagonal'.